### PR TITLE
Update python-igraph dependency to igraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.8"
 dependencies = [
     "scanpy>=1.9.5",
     "leidenalg>=0.10.1",
-    "python-igraph>=0.10.8",
+    "igraph>=0.10.8",
     "gseapy>=1.1.2"
 ]
 classifiers = [


### PR DESCRIPTION
I notice that even though this is a newly created GitHub repo, it contains a dependency on the long-ago deprecated python-igraph PyPI package. The updated name is igraph. Please see https://github.com/igraph/python-igraph/issues/699